### PR TITLE
chore(deps): Bump stable-ts to support whsiper 20231117

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tafrigh"
-version = "1.1.2"
+version = "1.1.3"
 description = "تفريغ النصوص وإنشاء ملفات SRT و VTT باستخدام نماذج Whisper وتقنية wit.ai."
 readme = "README.md"
 license = { file = "LICENSE" }
@@ -37,7 +37,7 @@ wit = [
 whisper = [
     "faster-whisper==0.10.0",
     "openai-whisper==20231117",
-    "stable-ts==2.8.1",
+    "stable-ts==2.13.4",
 ]
 
 [project.urls]


### PR DESCRIPTION
`stable-ts (2.8.1) depends on openai-whisper (20230314) and tafrigh (1.1.2) depends on openai-whisper (20231117)`