### PR TITLE
Remove yt-dlp upper version bound and bump to 1.7.7

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "tafrigh"
-version = "1.7.6"
+version = "1.7.7"
 description = "تفريغ النصوص وإنشاء ملفات SRT و VTT باستخدام نماذج Whisper وتقنية wit.ai."
 authors = ["EasyBooks <easybooksdev@gmail.com>"]
 license = "MIT"
@@ -26,7 +26,7 @@ repository = "https://github.com/ieasybooks/tafrigh"
 [tool.poetry.dependencies]
 python = ">=3.10"
 tqdm = ">=4.67.1"
-yt-dlp = {version = "^2025.3.31", extras = ["default"]}
+yt-dlp = {version = ">=2025.3.31", extras = ["default"]}
 auditok = ">=0.3.0"
 pydub = ">=0.25.1"
 requests = ">=2.32.0"


### PR DESCRIPTION
Change yt-dlp dependency from ^2025.3.31 (which caps at <2026) to
>=2025.3.31 to accept any future version.

https://claude.ai/code/session_01MT5gAGLF3Hw5GwwunQjumw