### PR TITLE
Fix auditok 0.4 audio region support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ repository = "https://github.com/ieasybooks/tafrigh"
 python = ">=3.10"
 tqdm = ">=4.67.1"
 yt-dlp = {version = ">=2025.3.31", extras = ["default"]}
-auditok = ">=0.3.0"
+auditok = ">=0.4.1"
 pydub = ">=0.25.1"
 requests = ">=2.32.0"
 faster-whisper = ">=1.1.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "tafrigh"
-version = "1.7.7"
+version = "1.7.8"
 description = "تفريغ النصوص وإنشاء ملفات SRT و VTT باستخدام نماذج Whisper وتقنية wit.ai."
 authors = ["EasyBooks <easybooksdev@gmail.com>"]
 license = "MIT"

--- a/tafrigh/audio_splitter.py
+++ b/tafrigh/audio_splitter.py
@@ -46,8 +46,8 @@ class AudioSplitter:
       return self._segments_to_data([
         (
           self._expand_segment_with_noise(segment, noise_seconds, noise_amplitude),
-          segment.meta.start,
-          segment.meta.end,
+          segment.start or 0,
+          (segment.start or 0) + segment.seconds.len,
         ) for segment in split(
           file_path,
           min_dur=min_dur,


### PR DESCRIPTION
## Summary
- Bump the auditok dependency floor to ">=0.4.1".
- Update AudioSplitter to use auditok 0.4 AudioRegion timing fields.

## Root cause
With auditok 0.4, split() yields AudioRegion objects that no longer expose the old meta attribute. The Wit path still read segment.meta.start and segment.meta.end, so transcription failed with:

```
AttributeError: 'AudioRegion' object has no attribute 'meta'
```

## Why this fixes it
auditok 0.4 keeps the segment offset on AudioRegion.start and exposes the segment duration through AudioRegion.seconds.len. The end timestamp is therefore start + seconds.len. Since this PR intentionally bumps the dependency to auditok >=0.4.1, the code can use the newer API directly with a minimal two-line replacement.

## Validation
- `uv run --no-project --python 3.12 --with auditok==0.4.1 --with pydub python -m py_compile tafrigh/audio_splitter.py`
- `uv run --no-project --python 3.12 --with isort isort --src tafrigh --line-length 120 --lines-between-types 1 --lines-after-imports 2 --check-only --diff tafrigh`
- `uv run --no-project --python 3.12 --with build python -m build --sdist --wheel --outdir /private/tmp/tafrigh-build-check-minimized`